### PR TITLE
Display terminal prompt defaults

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -93,7 +93,7 @@ if [[ "$UNINSTALL_MODE" = true ]]; then
     
     if [[ "$FORCE_INSTALL" != true ]]; then
         echo -e "${YELLOW}This will remove SuperClaude from $INSTALL_DIR${NC}"
-        echo -n "Are you sure you want to continue? (y/n): "
+        echo -n "Are you sure you want to continue? (y/N): "
         read -r confirm_uninstall
         if [ "$confirm_uninstall" != "y" ]; then
             echo "Uninstall cancelled."
@@ -133,7 +133,7 @@ if [[ "$FORCE_INSTALL" != true ]]; then
     else
         echo -e "${YELLOW}This will install SuperClaude in $INSTALL_DIR${NC}"
     fi
-    echo -n "Are you sure you want to continue? (y/n): "
+    echo -n "Are you sure you want to continue? (y/N): "
     read -r confirm_install
     if [ "$confirm_install" != "y" ]; then
         echo "Installation cancelled."
@@ -161,7 +161,7 @@ if [ -d "$INSTALL_DIR" ] && [ "$(ls -A "$INSTALL_DIR" 2>/dev/null)" ]; then
     if [[ "$UPDATE_MODE" = true ]] || [[ "$FORCE_INSTALL" = true ]]; then
         backup_choice="y"
     else
-        echo -n "Backup existing configuration? (y/n): "
+        echo -n "Backup existing configuration? (y/N): "
         read -r backup_choice
     fi
     


### PR DESCRIPTION
# Pull Request

## Legend
| Symbol | Meaning | | Abbrev | Meaning |
|--------|---------|---|--------|---------|
| → | leads to | | cfg | configuration |
| ✓ | completed | | PR | pull request |

## Summary
Terminal prompts (`y/n`) default to `n` ("don't take action"), make this clear by capitalizing the default (`N`).

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🎨 Code style/formatting change
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix

## Changes Made
- Updated all `y/n` in `install.sh` to `y/N`

## Testing
- [x] Tested install.sh on clean system
- [ ] Verified slash commands work in Claude Code
- [ ] Checked YAML syntax validity
- [ ] Tested persona functionality
- [ ] Tested MCP integration
- [ ] Manual testing performed
- [ ] All existing tests pass

## Related Issues
None

## Screenshots (if applicable)
<img width="344" alt="image" src="https://github.com/user-attachments/assets/10f06617-fba9-4183-8fd7-fcc95570f629" />

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes
Very minor change

## Breaking Changes
None

---
**Ready for review!** 🚀