### PR TITLE
fix: install script on macos

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -119,7 +119,12 @@ check_command() {
     fi
     
     # Check for dangerous command patterns (enhanced security)
-    if [[ "$cmd" =~ [;&|`$(){}\"\'\\] ]] || [[ "$cmd" =~ \.\.|^/ ]] || [[ "$cmd" =~ [[:space:]] ]]; then
+    # Check for various dangerous characters and patterns
+    if [[ "$cmd" == *";"* ]] || [[ "$cmd" == *"&"* ]] || [[ "$cmd" == *"|"* ]] || \
+       [[ "$cmd" == *'`'* ]] || [[ "$cmd" == *'$'* ]] || [[ "$cmd" == *"("* ]] || \
+       [[ "$cmd" == *")"* ]] || [[ "$cmd" == *"{"* ]] || [[ "$cmd" == *"}"* ]] || \
+       [[ "$cmd" == *'"'* ]] || [[ "$cmd" == *"'"* ]] || [[ "$cmd" == *"\\"* ]] || \
+       [[ "$cmd" == *".."* ]] || [[ "$cmd" == "/"* ]] || [[ "$cmd" == *[[:space:]]* ]]; then
         log_error "check_command: Invalid command name contains dangerous characters: $cmd"
         return 1
     fi
@@ -1363,7 +1368,7 @@ if [ -d "$INSTALL_DIR" ] && [ "$(ls -A "$INSTALL_DIR" 2>/dev/null)" ]; then
         backup_timestamp=$(date +%Y%m%d_%H%M%S)
         # Generate cryptographically secure random suffix - try multiple methods
         backup_random=""
-        local random_bytes=""
+        random_bytes=""
         
         # Try multiple secure random sources
         if [[ -r /dev/urandom ]]; then
@@ -1380,7 +1385,7 @@ if [ -d "$INSTALL_DIR" ] && [ "$(ls -A "$INSTALL_DIR" 2>/dev/null)" ]; then
             backup_random="$random_bytes"
         else
             # High-entropy fallback using multiple sources (improved)
-            local entropy_sources="$(date +%s%N 2>/dev/null)$$${RANDOM}${BASHPID:-$$}$(ps -eo pid,ppid,time 2>/dev/null | md5sum 2>/dev/null | cut -c1-8)"
+            entropy_sources="$(date +%s%N 2>/dev/null)$$${RANDOM}${BASHPID:-$$}$(ps -eo pid,ppid,time 2>/dev/null | md5sum 2>/dev/null | cut -c1-8)"
             backup_random=$(printf "%s" "$entropy_sources" | sha256sum 2>/dev/null | cut -c1-16)
         fi
         
@@ -1413,10 +1418,10 @@ if [ -d "$INSTALL_DIR" ] && [ "$(ls -A "$INSTALL_DIR" 2>/dev/null)" ]; then
             # Copy preserving permissions and symlinks, with security checks
             if [[ -e "$item" ]]; then
                 # Validate that item is within the installation directory (prevent symlink attacks)
-                local real_item
+                real_item=""
                 if command -v realpath &>/dev/null; then
                     real_item=$(realpath "$item" 2>/dev/null)
-                    local real_install_dir=$(realpath "$INSTALL_DIR" 2>/dev/null)
+                    real_install_dir=$(realpath "$INSTALL_DIR" 2>/dev/null)
                     if [[ -n "$real_item" ]] && [[ -n "$real_install_dir" ]] && [[ "$real_item" != "$real_install_dir"/* ]]; then
                         log_warning "Skipping backup of suspicious item outside install dir: $item"
                         continue


### PR DESCRIPTION
# Pull Request

## Legend
| Symbol | Meaning | | Abbrev | Meaning |
|--------|---------|---|--------|---------|
| → | leads to | | cfg | configuration |
| ✓ | completed | | PR | pull request |

## Summary
Fixed bash syntax errors in install.sh that prevented the script from running correctly on macOS/Darwin systems

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Configuration change
- [ ] 🎨 Code style/formatting change
- [ ] ♻️ Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🔒 Security fix

## Changes Made
- Fixed regex syntax error in `check_command` function (line 122) by replacing complex regex character class with simpler pattern matching
- Removed `local` keyword usage outside of functions (lines 1371, 1386, 1420, 1422) → variables now properly scoped
- Changed dangerous character detection from regex `[;&|...$]` pattern to individual glob pattern checks for better compatibility

## Testing
- [x] Tested install.sh on clean system
- [x] Verified script runs without syntax errors
- [x] Tested `--update` flag functionality
- [x] Manual testing performed
- [x] All existing tests pass

## Related Issues
Fixes bash compatibility issues on macOS Darwin 24.5.0

## Screenshots (if applicable)
<!-- No visual changes -->

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes
The script was failing with two types of errors:
1. `syntax error in conditional expression: unexpected token ';'` - caused by unescaped special characters in regex
2. `local: can only be used in a function` - caused by using the `local` keyword in the main script body

These fixes ensure the installer runs correctly on bash 3.2+ (including macOS default bash).

## Breaking Changes
None - these are bug fixes that restore intended functionality.

---
**Ready for review!** 🚀