### PR TITLE
fix table of contents links

### DIFF
--- a/Docs/superclaude-user-guide.md
+++ b/Docs/superclaude-user-guide.md
@@ -26,17 +26,17 @@ A comprehensive guide to understanding and using SuperClaude v3.0 effectively. B
 
 ## Table of Contents 📖
 
-1. [Welcome & Overview](#welcome--overview-👋)
-2. [Core Components](#core-components-🧩)
-3. [The Three Operational Modes](#the-three-operational-modes-🎭)
-4. [The Orchestrator System](#the-orchestrator-system-🎯)
-5. [Rules & Principles](#rules--principles-📏)
-6. [Getting Started Workflows](#getting-started-workflows-🛣️)
-7. [Integration & Coordination](#integration--coordination-🤝)
-8. [Practical Examples](#practical-examples-💡)
-9. [Tips & Best Practices](#tips--best-practices-🎯)
-10. [Troubleshooting](#troubleshooting--common-issues-🚨)
-11. [What's Next](#whats-next-🔮)
+1. [Welcome & Overview](#welcome--overview-)
+2. [Core Components](#core-components-)
+3. [The Three Operational Modes](#the-three-operational-modes-)
+4. [The Orchestrator System](#the-orchestrator-system-)
+5. [Rules & Principles](#rules--principles-)
+6. [Getting Started Workflows](#getting-started-workflows-)
+7. [Integration & Coordination](#integration--coordination-)
+8. [Practical Examples](#practical-examples-)
+9. [Tips & Best Practices](#tips--best-practices-)
+10. [Troubleshooting](#troubleshooting--common-issues-)
+11. [What's Next](#whats-next-)
 
 ---
 


### PR DESCRIPTION
really small fix to make the table of contents links work. because for headers with a emoji in them, the link just hides these.

(basically currently in the master branch you can't click a link on the table of contents to go to the section, i fixed this by simply removing the emoji)